### PR TITLE
Port stability detection added and more

### DIFF
--- a/src/DCSBIOSBridge/Interfaces/ISerialReceiver.cs
+++ b/src/DCSBIOSBridge/Interfaces/ISerialReceiver.cs
@@ -8,6 +8,6 @@ namespace DCSBIOSBridge.Interfaces;
 internal interface ISerialReceiver
 {
     SerialPort SerialPort { get; set; }
-    void Release();
+    void Dispose();
     void ReceiveTextOverSerial(object sender, SerialDataReceivedEventArgs e);
 }

--- a/src/DCSBIOSBridge/MainWindow.xaml
+++ b/src/DCSBIOSBridge/MainWindow.xaml
@@ -46,7 +46,7 @@
                 <MenuItem Header="Save" Name="MenuItemSave" Click="MenuItemSave_OnClick"/>
                 <MenuItem Header="Save As.." Name="MenuItemSaveAs" Click="MenuItemSaveAs_OnClick" />
                 <Separator />
-                <MenuItem Name ="MenuItemErrorLog" Header="Open error log" Click="MenuItemErrorLog_OnClick" />
+                <MenuItem Name ="MenuItemLogFile" Header="Open log" Click="MenuItemLogFile_OnClick" />
                 <Separator />
                 <MenuItem Header="Exit" Name="MenuItemExit" Click="MenuItemExit_OnClick" />
             </MenuItem>

--- a/src/DCSBIOSBridge/MainWindow.xaml.cs
+++ b/src/DCSBIOSBridge/MainWindow.xaml.cs
@@ -66,7 +66,7 @@ namespace DCSBIOSBridge
                 _dcsBios?.Dispose();
 
                 DBEventManager.BroadCastSerialPortUserControlStatus(SerialPortUserControlStatus.DoDispose);
-                _serialPortService.CleanUp();
+                _serialPortService.Dispose();
                 DBEventManager.DetachSerialPortStatusListener(this);
                 DBEventManager.DetachWindowsSerialPortEventListener(this);
                 DBEventManager.DetachSerialPortUserControlListener(this);
@@ -613,9 +613,9 @@ namespace DCSBIOSBridge
             }
         }
 
-        private void MenuItemErrorLog_OnClick(object sender, RoutedEventArgs e)
+        private void MenuItemLogFile_OnClick(object sender, RoutedEventArgs e)
         {
-            Common.TryOpenLogFileWithTarget("error_logfile");
+            Common.TryOpenLogFileWithTarget("logfile");
         }
 
         public void OnSettingsDirty(SettingsDirtyEventArgs args)

--- a/src/DCSBIOSBridge/NLog.config
+++ b/src/DCSBIOSBridge/NLog.config
@@ -4,13 +4,13 @@
       throwConfigExceptions="true">
 
   <targets>
-    <target name="error_logfile"
+    <target name="logfile"
             type="File"
-            fileName="${basedir}error_log.txt"
+            fileName="${basedir}dcsbiosbridge_log.txt"
             layout="${longdate}|${level}|${message}|${exception:format=Message,StackTrace}${newline}"/>
   </targets>
   
   <rules>
-    <logger name="*" minlevel="Error" writeTo="error_logfile" />
+    <logger name="*" minlevel="Info" writeTo="logfile" />
   </rules>
 </nlog>

--- a/src/DCSBIOSBridge/SerialPortClasses/SerialPortSetting.cs
+++ b/src/DCSBIOSBridge/SerialPortClasses/SerialPortSetting.cs
@@ -31,7 +31,6 @@ namespace DCSBIOSBridge.SerialPortClasses
                 LineSignalRts = bool.Parse(list[9])
             };
             result.LineSignalRts = bool.Parse(list[9]);
-            result.Connected = list[10].Equals(Constants.ProfileOpenKeyword);
             return result;
         }
 
@@ -47,8 +46,7 @@ namespace DCSBIOSBridge.SerialPortClasses
                           WriteTimeout + "|" +
                           ReadTimeout + "|" +
                           LineSignalDtr + "|" +
-                          LineSignalRts + "|" +
-                          (Connected ? Constants.ProfileOpenKeyword : Constants.ProfileClosedKeyword) + "}");
+                          LineSignalRts);
             return result.ToString();
         }
 
@@ -71,7 +69,5 @@ namespace DCSBIOSBridge.SerialPortClasses
         public bool LineSignalDtr { get; set; } = true;
 
         public bool LineSignalRts { get; set; }
-
-        public bool Connected { get; set; }
     }
 }

--- a/src/DCSBIOSBridge/SerialPortClasses/SerialReceiver.cs
+++ b/src/DCSBIOSBridge/SerialPortClasses/SerialReceiver.cs
@@ -14,7 +14,7 @@ namespace DCSBIOSBridge.SerialPortClasses;
 /// <summary>
 /// Handles reading from serial port.
 /// </summary>
-internal class SerialReceiver : ISerialReceiver
+internal class SerialReceiver : ISerialReceiver, IDisposable
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private SemaphoreSlim ReadFromSerialPortSemaphore { get; } = new(1);
@@ -22,10 +22,11 @@ internal class SerialReceiver : ISerialReceiver
     public SerialPort SerialPort { get; set; }
     private readonly StringBuilder _incomingData = new();
 
-    public void Release()
+    public void Dispose()
     {
         SerialPort.DataReceived -= ReceiveTextOverSerial;
-        SerialPort = null;
+        SerialPort.ErrorReceived -= SerialPortError;
+        ReadFromSerialPortSemaphore?.Dispose();
     }
 
     public async void ReceiveTextOverSerial(object sender, SerialDataReceivedEventArgs e)

--- a/src/DCSBIOSBridge/UserControls/SerialPortUserControl.xaml.cs
+++ b/src/DCSBIOSBridge/UserControls/SerialPortUserControl.xaml.cs
@@ -10,6 +10,7 @@ using DCSBIOSBridge.misc;
 using DCSBIOSBridge.Properties;
 using DCSBIOSBridge.SerialPortClasses;
 using DCSBIOSBridge.Windows;
+using NLog;
 
 namespace DCSBIOSBridge.UserControls
 {
@@ -29,6 +30,8 @@ namespace DCSBIOSBridge.UserControls
     /// </summary>
     public partial class SerialPortUserControl : ISerialPortStatusListener, ISerialPortUserControlListener, ISerialDataListener, INotifyPropertyChanged, IDisposable
     {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         private readonly SerialPortShell _serialPortShell;
         private double _bytesFromDCSBIOS;
         private double _bytesFromSerialPort;
@@ -143,11 +146,11 @@ namespace DCSBIOSBridge.UserControls
                     case SerialPortStatus.Ok:
                         break;
                     case SerialPortStatus.Critical:
-                        break;
                     case SerialPortStatus.Error:
                     case SerialPortStatus.IOError:
                     case SerialPortStatus.TimeOutError:
                         {
+                            Logger.Error($"(SerialPortUserControl) Error detected on {e.SerialPortName}. I am closing myself (& port) down.");
                             BroadCastClosedAndDispose(SerialPortUserControlStatus.Closed);
                             break;
                         }

--- a/src/DCSBIOSBridge/misc/Common.cs
+++ b/src/DCSBIOSBridge/misc/Common.cs
@@ -16,12 +16,12 @@ namespace DCSBIOSBridge.misc
         public static readonly Encoding UsedEncoding = Encoding.GetEncoding(28591);
 
 
-        public static string[] GetSerialPortNames()
+        public static List<string> GetSerialPortNames()
         {
             /*
              * Sometimes when disconnecting cables this can return same port listed 3 times.
              */
-            return SerialPort.GetPortNames().Distinct().ToArray();
+            return SerialPort.GetPortNames().Distinct().ToList();
         }
 
         public static Microsoft.Win32.OpenFileDialog OpenFileDialog(string initialDirectory)

--- a/src/DCSBIOSBridge/misc/Constants.cs
+++ b/src/DCSBIOSBridge/misc/Constants.cs
@@ -19,8 +19,6 @@
         public const string ProfileFilter = "(.dcs-bios_settings)|*.dcs-bios_settings";
         public const string ProfileSettingKeyword = "SerialPort{";
         public const string ProfileHiddenKeyword = "HiddenList{";
-        public const string ProfileOpenKeyword = "Open";
-        public const string ProfileClosedKeyword = "Closed";
 
         /*
          * 15.03.2024 JDA


### PR DESCRIPTION
* SerialPort in SerialPortShell disposed when GUI "port" is closed.
* SerialReceiver disposable
* Background thread is monitoring SerialPort.IsOpen every 1 sec. This detects when an open port USB cable is disconnected.
* Changed to general log file instead of just errors.
* Logging more events